### PR TITLE
Update laplacian-ricci.jl to fit general distance matrix

### DIFF
--- a/RicciCurvatures/src/laplacian-ricci.jl
+++ b/RicciCurvatures/src/laplacian-ricci.jl
@@ -20,8 +20,9 @@ function κ(
     here = unique( [neighbors(G, e.src)..., neighbors(G, e.dst)...] )
     n = length(here)
 
-    d = view(D, here, here)
-    δ = view(Δ, here, here)
+    d  = view(D, here, here)
+    δ  = view(Δ, here, here)
+    De = D[e.src,e.dst]
     
     model = Model(optimizer)
     @variable(model, f[1:n])
@@ -30,14 +31,14 @@ function κ(
     @constraint(model, .- d .≤ [f[x] - f[y] for x ∈ 1:n, y ∈ 1:n] .≤ d) 
 
     # ∇ₑf = 1
-    @constraint(model, ∇(f, e, here) == 1)
+    @constraint(model, ∇(f, e, here) == De)
     
     # inf ∇ₑΔf
     @objective(model, Min, ∇(δ * f, e, here))
 
     optimize!(model)
 
-    return objective_value(model)
+    return objective_value(model)/De
 
 end
 

--- a/RicciCurvatures/test/runtests.jl
+++ b/RicciCurvatures/test/runtests.jl
@@ -1,7 +1,7 @@
 using Distributed
 addprocs(Sys.CPU_THREADS)
 
-@everywhere begin 
+@everywhere begin
     using Pkg; Pkg.activate(".")
     using Test
     using RicciCurvatures
@@ -42,7 +42,5 @@ using BenchmarkTools
     G = Graphs.SimpleGraphs.erdos_renyi(50, 200)
     T_seq = @belapsed κ($G; parallel = false)
     T_par = @belapsed κ($G; parallel = true)
-    @test T_par < T_seq 
-    end
+    @test T_par < T_seq
 end
-

--- a/RicciCurvatures/test/runtests2.jl
+++ b/RicciCurvatures/test/runtests2.jl
@@ -1,0 +1,26 @@
+using Test
+using RicciCurvatures
+using Graphs
+
+@testset "Square" begin
+    V =5
+    #E = 4
+    G = SimpleGraph(V);
+    add_edge!(G, 1, 2)
+    add_edge!(G, 1, 3)
+    add_edge!(G, 1, 4)
+    add_edge!(G, 2, 5)
+    #add_edge!(G, 4, 1)
+
+
+    #@test κ(G) ≈ fill(V/2, E)
+    println(κ(G))
+end
+
+#@testset "Complete graphs" begin
+#    for V in 2:10
+#        E = Int(V * (V-1) / 2)
+#        G = complete_graph(V);
+#        @test κ(G) ≈ fill(V, E)
+#    end
+#end


### PR DESCRIPTION
For generalizing to general distance matricies D, we need to compare gradient f(x,y) with D(x,y), not with one. Also, for getting the curvature, the final result has to be divided by D(x,y). For the standard shortest path metric, it makes no difference though.